### PR TITLE
fix(plugins): Use correct plugin ID on SpinnakerExtension annotation

### DIFF
--- a/helloworld-orca/src/main/java/com/robzienert/spinnaker/plugin/helloworld/orca/HelloWorldPlugin.java
+++ b/helloworld-orca/src/main/java/com/robzienert/spinnaker/plugin/helloworld/orca/HelloWorldPlugin.java
@@ -50,7 +50,7 @@ public class HelloWorldPlugin extends Plugin {
    * It says hello.
    */
   @Extension
-  @SpinnakerExtension(id = "com.robzienert.helloworld-stage")
+  @SpinnakerExtension(id = "com.robzienert.helloworld")
   public static class HelloWorldStage implements
     SimpleStage<HelloWorldStage.Input>,
     ConfigurableExtension<HelloWorldStageConfigProperties> {


### PR DESCRIPTION
`SpinnakerExtension` is currently only used to load the correct plugin config, and the ID has to match for that work.  There is still a requirement on using pf4j's `Extension` annotation.  This is indirect and a bit confusing.

I'd like to see us clean this up eventually, such that either `SpinnakerExtension` is deleted and we require plugin devs to have pf4j as a dependency or we go the other route and extends pf4j's `Plugin`, `PluginWrapper`, and make `SpinnakerExtension` work and remove the requirement of plugin devs to include pf4j as a dependency.  Either way, it's kinda funky right now.

Anyways, this solves the immediate issue. 